### PR TITLE
[FEAT] Add Deployment action for docs

### DIFF
--- a/.github/workflows/docsDeployment.yaml
+++ b/.github/workflows/docsDeployment.yaml
@@ -1,0 +1,28 @@
+name: Deploy Documentation 
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/.github/workflows/docsDeployment.yaml
+++ b/.github/workflows/docsDeployment.yaml
@@ -1,28 +1,24 @@
-name: Deploy Documentation 
+name: Deploy Documentation
 on:
   push:
     branches:
       - main
-permissions:
-  contents: write
 jobs:
-  deploy:
+  build:
+    name: Deploy docs to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
+      - name: Checkout 
+        uses: actions/checkout@v2
+      - name: Build
+        uses: Tiryoh/actions-mkdocs@v0
         with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
+          mkdocs_version: 'latest'
+          configfile: 'mkdocs.yml'
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache 
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force
+            personal_token: ${{ secrets.GITHUB_TOKEN }}
+            publish_dir: ./site
+            user_name: "github-actions[bot]"
+            user_email: "github-actions[bot]@users.noreply.github.com"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Glückliche Rinne
+
+> "Glückliche Rinne" (a questionable German translation of a subversive twist on "Lucky Strike") is a statically-typed, imperative programming language developed as part of an academic course on compiler construction. I mean, what else could it possibly be? 😄
+
+## 🤝 Contributing
+
+Pull requests are welcome! For major changes, please open an issue first to discuss what you’d like to change.
+
+Please make sure to update tests and documentation as appropriate.


### PR DESCRIPTION
# Description 
I added a GH action that builds the docs and moves them to a branch called `gh-pages` this branch only contains the hostable files (html, css, js, etc.).
In order to have an index page I also added an index.md file (otherwise we are presented a 404 page if we first visit the docs).
## Tested
- [X] tested and worked in fork

## Tasks for the repo-maintainer
@marco-haupt you need to enable gh-pages in the repo settings and select the `gh-pages` branch to be used as resource for that. (instruction can be found [here](https://docs.github.com/en/pages/quickstart#creating-your-website))